### PR TITLE
add open method to WorkerLogic trait

### DIFF
--- a/src/main/scala/hu/sztaki/ilab/ps/FlinkParameterServer.scala
+++ b/src/main/scala/hu/sztaki/ilab/ps/FlinkParameterServer.scala
@@ -228,6 +228,7 @@ object FlinkParameterServer {
 
 
             override def open(parameters: Configuration): Unit = {
+              logic.open()
               psClient.setPartitionId(getRuntimeContext.getIndexOfThisSubtask)
             }
 

--- a/src/main/scala/hu/sztaki/ilab/ps/WorkerLogic.scala
+++ b/src/main/scala/hu/sztaki/ilab/ps/WorkerLogic.scala
@@ -20,6 +20,11 @@ import scala.util.{Success, Try}
 trait WorkerLogic[T, P, WOut] extends Serializable {
 
   /**
+    * Method called when the process is started
+    */
+  def open(): Unit ={}
+
+  /**
     * Method called when new data arrives.
     *
     * @param data


### PR DESCRIPTION
In order to let the programmer implement some logic that will be computed inside the open method of the Flink operator.